### PR TITLE
Add web dashboard for managing data transfer jobs

### DIFF
--- a/dashboard.yaml.example
+++ b/dashboard.yaml.example
@@ -1,0 +1,77 @@
+# xfer Dashboard Configuration
+# Copy to /etc/xfer/dashboard.yaml or ~/.config/xfer/dashboard.yaml
+
+schema: xfer.dashboard.config.v1
+
+# Authentication
+auth:
+  google:
+    # Create OAuth2 credentials at https://console.cloud.google.com/apis/credentials
+    client_id: "YOUR_CLIENT_ID.apps.googleusercontent.com"
+    client_secret: "YOUR_CLIENT_SECRET"
+    # Only allow users from these email domains
+    allowed_domains:
+      - "example.com"
+  session:
+    # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+    secret_key: "CHANGE_ME_GENERATE_A_RANDOM_64_CHAR_HEX_STRING"
+    cookie_name: "xfer_session"
+    max_age_seconds: 86400  # 24 hours
+
+# Database
+database:
+  # SQLite for development
+  url: "sqlite+aiosqlite:///var/lib/xfer/dashboard.db"
+  # PostgreSQL for production:
+  # url: "postgresql+asyncpg://user:password@localhost/xfer"
+
+# Slurm job settings (admin-controlled, not user-editable)
+slurm:
+  # Container image for rclone
+  rclone_image: "rclone/rclone:latest"
+
+  # Path to rclone.conf on the cluster
+  rclone_config: "/shared/config/rclone/rclone.conf"
+
+  # Default number of shards for parallel transfers
+  num_shards: 256
+
+  # Maximum concurrent Slurm array tasks
+  array_concurrency: 64
+
+  # Available partitions (first is default)
+  partitions:
+    - "transfer"
+    - "standard"
+
+  # Resource limits per task
+  cpus_per_task: 4
+  mem: "8G"
+  time_limit: "24:00:00"
+  max_attempts: 5
+
+  # rclone copy flags
+  rclone_flags: "--transfers 32 --checkers 64 --fast-list --retries 10 --low-level-retries 20"
+
+  # Extra pyxis flags (optional)
+  pyxis_extra: ""
+
+# Path restrictions
+paths:
+  # Base directory where job run directories will be created
+  run_base_dir: "/scratch/xfer-runs"
+
+  # Allowed source/destination path prefixes
+  # Users can only select paths matching these patterns
+  allowed_prefixes:
+    - "s3src:"       # Allow any path on s3src remote
+    - "s3dst:"       # Allow any path on s3dst remote
+    - "/scratch/"    # Local scratch filesystem
+
+# Dashboard server settings
+server:
+  host: "0.0.0.0"
+  port: 8000
+  # Public URL for OAuth callbacks (must match Google Cloud Console redirect URI)
+  base_url: "https://xfer.example.com"
+  debug: false

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,470 @@
+# xfer Web Dashboard
+
+The xfer web dashboard provides a browser-based interface for managing data transfer jobs on Slurm clusters. Users can create transfers, monitor progress, view logs, and cancel jobs without using the command line.
+
+## Features
+
+- **Google Workspace SSO** - Authenticate users via Google OAuth with domain restrictions
+- **Simplified Job Creation** - Users select source/destination from pre-configured remotes
+- **Admin-Controlled Settings** - Shard count, concurrency, partitions, and resource limits are pre-configured
+- **Real-Time Progress** - Monitor shard completion with automatic polling
+- **Log Streaming** - View manifest and shard logs directly in the browser
+- **Job Cancellation** - Cancel running jobs from the dashboard
+
+## Prerequisites
+
+### 1. Google Cloud OAuth Credentials
+
+The dashboard uses Google Workspace SSO for authentication. You'll need to create OAuth 2.0 credentials:
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Navigate to **APIs & Services > Credentials**
+4. Click **Create Credentials > OAuth client ID**
+5. Select **Web application**
+6. Add authorized redirect URI: `https://your-dashboard-url/auth/callback`
+7. Save the **Client ID** and **Client Secret**
+
+### 2. rclone Configuration
+
+Ensure you have an `rclone.conf` file with your S3 remotes configured:
+
+```ini
+[s3-source]
+type = s3
+provider = Other
+endpoint = https://s3.source.example.com
+access_key_id = YOUR_ACCESS_KEY
+secret_access_key = YOUR_SECRET_KEY
+
+[s3-dest]
+type = s3
+provider = Other
+endpoint = https://s3.dest.example.com
+access_key_id = YOUR_ACCESS_KEY
+secret_access_key = YOUR_SECRET_KEY
+```
+
+### 3. Slurm Cluster Access
+
+The dashboard must run on a node with:
+- Access to `sbatch`, `scancel`, and `sacct` commands
+- Network access to submit jobs to the Slurm controller
+- Read access to the rclone.conf file
+- Write access to the run base directory
+
+## Installation
+
+Install xfer with the dashboard extras:
+
+```bash
+pip install "xfer[dashboard]"
+```
+
+Or install from source:
+
+```bash
+cd /path/to/xfer
+pip install -e ".[dashboard]"
+```
+
+## Configuration
+
+Create a configuration file at one of these locations (checked in order):
+
+1. Path specified by `XFER_DASHBOARD_CONFIG` environment variable
+2. `/etc/xfer/dashboard.yaml`
+3. `~/.config/xfer/dashboard.yaml`
+4. `./dashboard.yaml` (current directory)
+
+### Configuration Reference
+
+```yaml
+# Schema version (required)
+schema: xfer.dashboard.config.v1
+
+# Authentication settings
+auth:
+  google:
+    # OAuth credentials from Google Cloud Console
+    client_id: "YOUR_CLIENT_ID.apps.googleusercontent.com"
+    client_secret: "YOUR_CLIENT_SECRET"
+
+    # Only allow users from these email domains
+    allowed_domains:
+      - "yourcompany.com"
+      - "subsidiary.org"
+
+  session:
+    # Secret key for signing session cookies
+    # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+    secret_key: "your-64-character-hex-string"
+
+    # Session cookie name
+    cookie_name: "xfer_session"
+
+    # Session lifetime in seconds (default: 24 hours)
+    max_age_seconds: 86400
+
+# Database settings
+database:
+  # SQLite (development)
+  url: "sqlite+aiosqlite:///var/lib/xfer/dashboard.db"
+
+  # PostgreSQL (production)
+  # url: "postgresql+asyncpg://user:password@localhost/xfer"
+
+# Slurm job settings (admin-controlled, not user-editable)
+slurm:
+  # Container image containing rclone
+  rclone_image: "rclone/rclone:latest"
+
+  # Path to rclone.conf on the cluster (mounted into containers)
+  rclone_config: "/shared/config/rclone/rclone.conf"
+
+  # Number of shards for parallel transfers
+  num_shards: 256
+
+  # Maximum concurrent Slurm array tasks
+  array_concurrency: 64
+
+  # Available partitions (first is default)
+  partitions:
+    - "transfer"
+    - "standard"
+
+  # Resource limits per task
+  cpus_per_task: 4
+  mem: "8G"
+  time_limit: "24:00:00"
+  max_attempts: 5
+
+  # rclone copy flags
+  rclone_flags: "--transfers 32 --checkers 64 --fast-list --retries 10 --low-level-retries 20"
+
+  # Extra pyxis flags (optional)
+  pyxis_extra: ""
+
+# Path restrictions
+paths:
+  # Base directory for job run directories
+  # Each job creates: {run_base_dir}/xfer_{tag}_{run_id}/
+  run_base_dir: "/scratch/xfer-runs"
+
+  # Allowed source/destination path prefixes
+  # Users can only select paths matching these patterns
+  allowed_prefixes:
+    - "s3-source:"    # Allow s3-source remote
+    - "s3-dest:"      # Allow s3-dest remote
+    - "/scratch/"     # Allow local /scratch filesystem
+
+# Server settings
+server:
+  host: "0.0.0.0"
+  port: 8000
+
+  # Public URL (must match Google OAuth redirect URI)
+  base_url: "https://xfer.yourcompany.com"
+
+  # Enable debug mode (disables HTTPS-only cookies)
+  debug: false
+```
+
+## Running the Dashboard
+
+### Development
+
+```bash
+# Set config path (optional)
+export XFER_DASHBOARD_CONFIG=/path/to/dashboard.yaml
+
+# Run with the built-in server
+xfer-dashboard
+```
+
+The dashboard will be available at `http://localhost:8000`.
+
+### Production with Gunicorn
+
+For production deployments, use Gunicorn with Uvicorn workers:
+
+```bash
+pip install gunicorn
+
+gunicorn xfer.dashboard.main:create_app \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --workers 4 \
+    --bind 0.0.0.0:8000
+```
+
+### Production with systemd
+
+Create `/etc/systemd/system/xfer-dashboard.service`:
+
+```ini
+[Unit]
+Description=xfer Dashboard
+After=network.target
+
+[Service]
+Type=exec
+User=xfer
+Group=xfer
+Environment=XFER_DASHBOARD_CONFIG=/etc/xfer/dashboard.yaml
+ExecStart=/usr/local/bin/gunicorn xfer.dashboard.main:create_app \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --workers 4 \
+    --bind 127.0.0.1:8000
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable xfer-dashboard
+sudo systemctl start xfer-dashboard
+```
+
+### Reverse Proxy (nginx)
+
+Place behind nginx for TLS termination:
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name xfer.yourcompany.com;
+
+    ssl_certificate /etc/ssl/certs/xfer.crt;
+    ssl_certificate_key /etc/ssl/private/xfer.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE support for log streaming
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+    }
+}
+```
+
+## Architecture
+
+### Two-Stage Job Submission
+
+The dashboard uses a two-stage approach to keep all computation off the login node:
+
+```
+┌─────────────────┐
+│   Dashboard     │
+│  (Login Node)   │
+└────────┬────────┘
+         │ sbatch manifest_job.sh
+         ▼
+┌─────────────────┐
+│  Manifest Job   │  Stage 1: Single Slurm job
+│  (Compute Node) │
+│                 │
+│  1. xfer manifest build
+│  2. xfer manifest shard
+│  3. xfer slurm render
+│  4. sbatch sbatch_array.sh ──────┐
+└─────────────────┘                │
+                                   ▼
+                    ┌─────────────────────────┐
+                    │    Transfer Array Job   │  Stage 2: Array job
+                    │    (Compute Nodes)      │
+                    │                         │
+                    │  Task 0: shard_000000   │
+                    │  Task 1: shard_000001   │
+                    │  ...                    │
+                    │  Task N: shard_NNNNNN   │
+                    └─────────────────────────┘
+```
+
+### Job Status Flow
+
+```
+pending
+    │
+    ▼ (dashboard submits manifest job)
+manifest_queued
+    │
+    ▼ (Slurm starts manifest job)
+manifest_running
+    │
+    ├──▶ manifest_failed (on error)
+    │
+    ▼ (manifest job completes, submits array)
+manifest_done
+    │
+    ▼
+transfer_queued
+    │
+    ▼ (Slurm starts array tasks)
+transfer_running
+    │
+    ├──▶ failed (too many shard failures)
+    │
+    ▼ (all shards complete)
+completed
+```
+
+### Run Directory Structure
+
+Each job creates a run directory:
+
+```
+/scratch/xfer-runs/xfer_{tag}_{run_id}/
+├── manifest_job.sh          # Submitted by dashboard
+├── manifest.out             # Manifest job stdout
+├── manifest.err             # Manifest job stderr
+├── manifest.jsonl           # Object listing
+├── transfer_job_id.txt      # Transfer array job ID
+├── worker.sh                # Per-shard worker script
+├── sbatch_array.sh          # Array job submission script
+├── config.resolved.json     # Frozen configuration
+├── shards/
+│   ├── shard_000000.jsonl
+│   ├── shard_000001.jsonl
+│   ├── ...
+│   └── shards.meta.json     # Shard metadata
+├── state/
+│   ├── shard_0.done         # Empty file = shard complete
+│   ├── shard_0.attempt      # Attempt count
+│   ├── shard_5.fail         # Exit code on failure
+│   └── ...
+└── logs/
+    ├── shard_0_attempt_1.log
+    ├── shard_5_attempt_1.log
+    ├── shard_5_attempt_2.log  # Retry log
+    └── ...
+```
+
+## API Reference
+
+### HTML Pages
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/` | GET | Dashboard home (redirects to /jobs) |
+| `/login` | GET | Login page |
+| `/jobs` | GET | Job list page |
+| `/jobs/new` | GET | Job creation form |
+| `/jobs/{id}` | GET | Job detail page |
+
+### Authentication
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/auth/login` | GET | Initiate Google OAuth flow |
+| `/auth/callback` | GET | OAuth callback (redirect URI) |
+| `/auth/logout` | GET | Log out and clear session |
+
+### Job Management
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/jobs` | POST | Create new transfer job |
+| `/jobs/{id}/cancel` | POST | Cancel a running job |
+| `/api/jobs` | GET | List jobs (JSON) |
+| `/api/jobs/{id}` | GET | Get job details (JSON) |
+
+### Remote Discovery
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/remotes` | GET | List available remotes and local prefixes |
+| `/api/remotes/sources` | GET | List source options for form dropdowns |
+
+### Log Access
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/logs/{job_id}/manifest` | GET | Stream manifest log (SSE) |
+| `/api/logs/{job_id}/manifest/content` | GET | Get manifest log content |
+| `/api/logs/{job_id}/shard/{shard_id}` | GET | Get shard log content |
+| `/api/logs/{job_id}/shards` | GET | List available shard logs |
+
+### HTMX Partials
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/htmx/jobs/table` | GET | Jobs table (for polling) |
+| `/htmx/jobs/{id}/progress` | GET | Progress bar (for polling) |
+
+### Health Check
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Health check (returns `{"status": "ok"}`) |
+
+## Security Considerations
+
+### Path Validation
+
+All user-provided paths are validated against `allowed_prefixes` to prevent:
+- Access to unauthorized S3 buckets
+- Access to unauthorized filesystem paths
+- Directory traversal attacks
+
+### Shell Injection Prevention
+
+All user inputs interpolated into shell scripts use `shlex.quote()` for proper escaping.
+
+### Session Security
+
+- Sessions are signed with HMAC using the configured secret key
+- Cookies are `httponly` (not accessible to JavaScript)
+- Cookies use `samesite=lax` to prevent CSRF
+- In production (`debug: false`), cookies require HTTPS
+
+### Log Access Control
+
+Log file paths are validated to ensure they're within the job's run directory, preventing directory traversal.
+
+### Domain Restriction
+
+Google OAuth domain restriction is enforced server-side. Only users with email addresses from `allowed_domains` can authenticate.
+
+## Troubleshooting
+
+### "No dashboard configuration file found"
+
+Create a config file at one of the expected locations or set `XFER_DASHBOARD_CONFIG`.
+
+### OAuth redirect URI mismatch
+
+Ensure `server.base_url` in your config matches the redirect URI configured in Google Cloud Console. The callback URL is `{base_url}/auth/callback`.
+
+### "Domain not allowed" error
+
+The user's email domain is not in `auth.google.allowed_domains`. Add their domain to the list.
+
+### Jobs stuck in "manifest_queued"
+
+Check that:
+1. The dashboard host can reach the Slurm controller
+2. The user running the dashboard has permission to submit jobs
+3. The partition specified exists and is accessible
+
+### Progress not updating
+
+The dashboard polls the state directory every 30 seconds. Check that:
+1. The run directory is accessible from the dashboard host
+2. The worker jobs are writing state files correctly
+
+### Log streaming not working
+
+If behind a reverse proxy, ensure:
+1. Proxy buffering is disabled
+2. The proxy timeout is sufficient for long-lived SSE connections

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,24 @@ dependencies = [
   "rich>=13.7.1",
 ]
 
+[project.optional-dependencies]
+dashboard = [
+    "fastapi>=0.109.0",
+    "uvicorn[standard]>=0.27.0",
+    "jinja2>=3.1.0",
+    "python-multipart>=0.0.6",
+    "sqlalchemy[asyncio]>=2.0.0",
+    "aiosqlite>=0.19.0",
+    "fastapi-sso>=0.14.0",
+    "itsdangerous>=2.1.0",
+    "pyyaml>=6.0",
+    "aiofiles>=23.0.0",
+    "starlette>=0.35.0",
+]
+
 [project.scripts]
 xfer = "xfer.cli:main"
+xfer-dashboard = "xfer.dashboard.main:run"
 
 [build-system]
 requires = ["hatchling>=1.25.0"]

--- a/src/xfer/dashboard/__init__.py
+++ b/src/xfer/dashboard/__init__.py
@@ -1,0 +1,3 @@
+"""xfer web dashboard for managing data transfer jobs."""
+
+__version__ = "0.1.0"

--- a/src/xfer/dashboard/api/__init__.py
+++ b/src/xfer/dashboard/api/__init__.py
@@ -1,0 +1,1 @@
+"""API routes for the dashboard."""

--- a/src/xfer/dashboard/api/jobs.py
+++ b/src/xfer/dashboard/api/jobs.py
@@ -1,0 +1,287 @@
+"""API endpoints for job management."""
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import User, require_auth
+from ..db.models import Job
+from ..db.session import get_db
+from ..services.job_service import JobService
+from ..services.rclone_service import get_allowed_local_prefixes, get_allowed_remotes
+from ..services.state_service import StateService
+
+router = APIRouter(tags=["jobs"])
+
+
+@router.get("/jobs", response_class=HTMLResponse)
+async def list_jobs_page(
+    request: Request,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all jobs page."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    jobs = await job_service.list_jobs(limit=100)
+
+    return request.app.state.templates.TemplateResponse(
+        "jobs/list.html",
+        {"request": request, "user": user, "jobs": jobs},
+    )
+
+
+@router.get("/jobs/new", response_class=HTMLResponse)
+async def new_job_page(
+    request: Request,
+    user: User = Depends(require_auth),
+):
+    """Show job creation form."""
+    config = request.app.state.config
+
+    # Get available remotes and local prefixes
+    remotes = get_allowed_remotes(
+        config.slurm.rclone_config,
+        config.paths.allowed_prefixes,
+    )
+    local_prefixes = get_allowed_local_prefixes(config.paths.allowed_prefixes)
+
+    return request.app.state.templates.TemplateResponse(
+        "jobs/create.html",
+        {
+            "request": request,
+            "user": user,
+            "config": config,
+            "remotes": remotes,
+            "local_prefixes": local_prefixes,
+        },
+    )
+
+
+@router.post("/jobs")
+async def create_job(
+    request: Request,
+    tag: str = Form(...),
+    source_path: str = Form(...),
+    dest_path: str = Form(...),
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new transfer job."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+
+    try:
+        job = await job_service.create_job(
+            tag=tag,
+            source_path=source_path,
+            dest_path=dest_path,
+            user_id=user.id,
+        )
+        return RedirectResponse(url=f"/jobs/{job.id}", status_code=303)
+    except ValueError as e:
+        # Re-render form with error
+        remotes = get_allowed_remotes(
+            config.slurm.rclone_config,
+            config.paths.allowed_prefixes,
+        )
+        local_prefixes = get_allowed_local_prefixes(config.paths.allowed_prefixes)
+
+        return request.app.state.templates.TemplateResponse(
+            "jobs/create.html",
+            {
+                "request": request,
+                "user": user,
+                "config": config,
+                "remotes": remotes,
+                "local_prefixes": local_prefixes,
+                "error": str(e),
+                "form_data": {"tag": tag, "source_path": source_path, "dest_path": dest_path},
+            },
+            status_code=400,
+        )
+
+
+@router.get("/jobs/{job_id}", response_class=HTMLResponse)
+async def job_detail_page(
+    request: Request,
+    job_id: int,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Show job detail page."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    job = await job_service.get_job(job_id)
+
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Get progress from state directory
+    state_service = StateService()
+    progress = None
+    if job.num_shards:
+        progress = state_service.get_job_progress(Path(job.run_dir), job.num_shards)
+
+    return request.app.state.templates.TemplateResponse(
+        "jobs/detail.html",
+        {
+            "request": request,
+            "user": user,
+            "job": job,
+            "progress": progress,
+        },
+    )
+
+
+@router.post("/jobs/{job_id}/cancel")
+async def cancel_job(
+    request: Request,
+    job_id: int,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Cancel a running job."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+
+    try:
+        await job_service.cancel_job(job_id)
+        return RedirectResponse(url=f"/jobs/{job_id}", status_code=303)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+# HTMX partials
+
+
+@router.get("/htmx/jobs/table", response_class=HTMLResponse)
+async def jobs_table_partial(
+    request: Request,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Partial: jobs table for htmx polling."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    jobs = await job_service.list_jobs(limit=100)
+
+    return request.app.state.templates.TemplateResponse(
+        "partials/job_table.html",
+        {"request": request, "jobs": jobs},
+    )
+
+
+@router.get("/htmx/jobs/{job_id}/progress", response_class=HTMLResponse)
+async def job_progress_partial(
+    request: Request,
+    job_id: int,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Partial: job progress for htmx polling."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    job = await job_service.get_job(job_id)
+
+    if job is None:
+        return HTMLResponse("<div>Job not found</div>", status_code=404)
+
+    # Get progress from state directory
+    state_service = StateService()
+    progress = None
+    if job.num_shards:
+        progress = state_service.get_job_progress(Path(job.run_dir), job.num_shards)
+
+    return request.app.state.templates.TemplateResponse(
+        "partials/progress_bar.html",
+        {"request": request, "job": job, "progress": progress},
+    )
+
+
+# JSON API endpoints
+
+
+@router.get("/api/jobs")
+async def list_jobs_api(
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+    request: Request = None,
+):
+    """List jobs as JSON."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    jobs = await job_service.list_jobs(limit=100)
+
+    return [
+        {
+            "id": job.id,
+            "tag": job.tag,
+            "status": job.status,
+            "source_path": job.source_path,
+            "dest_path": job.dest_path,
+            "created_at": job.created_at.isoformat() if job.created_at else None,
+            "num_shards": job.num_shards,
+            "shards_done": job.shards_done,
+            "shards_failed": job.shards_failed,
+            "progress_percent": job.progress_percent,
+        }
+        for job in jobs
+    ]
+
+
+@router.get("/api/jobs/{job_id}")
+async def get_job_api(
+    job_id: int,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+    request: Request = None,
+):
+    """Get job details as JSON."""
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    job = await job_service.get_job(job_id)
+
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Get progress
+    state_service = StateService()
+    progress = None
+    if job.num_shards:
+        progress = state_service.get_job_progress(Path(job.run_dir), job.num_shards)
+
+    return {
+        "id": job.id,
+        "tag": job.tag,
+        "status": job.status,
+        "source_path": job.source_path,
+        "dest_path": job.dest_path,
+        "run_id": job.run_id,
+        "run_dir": job.run_dir,
+        "manifest_slurm_job_id": job.manifest_slurm_job_id,
+        "transfer_slurm_job_id": job.transfer_slurm_job_id,
+        "created_at": job.created_at.isoformat() if job.created_at else None,
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+        "num_shards": job.num_shards,
+        "shards_done": job.shards_done,
+        "shards_failed": job.shards_failed,
+        "shards_running": job.shards_running,
+        "total_bytes": job.total_bytes,
+        "manifest_object_count": job.manifest_object_count,
+        "progress_percent": job.progress_percent,
+        "error_message": job.error_message,
+        "progress": {
+            "total": progress.total_shards,
+            "done": progress.done,
+            "failed": progress.failed,
+            "running": progress.running,
+            "pending": progress.pending,
+        }
+        if progress
+        else None,
+    }

--- a/src/xfer/dashboard/api/logs.py
+++ b/src/xfer/dashboard/api/logs.py
@@ -1,0 +1,246 @@
+"""API endpoints for log streaming."""
+
+import asyncio
+from pathlib import Path
+from typing import Optional
+
+import aiofiles
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth import User, require_auth
+from ..db.session import get_db
+from ..services.job_service import JobService
+
+router = APIRouter(prefix="/api/logs", tags=["logs"])
+
+
+def _validate_log_path(job_run_dir: str, log_path: Path) -> bool:
+    """Validate that a log path is within the job's run directory.
+
+    Prevents directory traversal attacks.
+
+    Args:
+        job_run_dir: Job's run directory.
+        log_path: Requested log path.
+
+    Returns:
+        True if path is valid and safe.
+    """
+    try:
+        run_dir = Path(job_run_dir).resolve()
+        resolved_path = log_path.resolve()
+        return str(resolved_path).startswith(str(run_dir))
+    except (ValueError, OSError):
+        return False
+
+
+@router.get("/{job_id}/manifest")
+async def stream_manifest_log(
+    request: Request,
+    job_id: int,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Stream manifest job log via Server-Sent Events.
+
+    Args:
+        job_id: Job ID.
+
+    Returns:
+        SSE stream of log content.
+    """
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    job = await job_service.get_job(job_id)
+
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    log_path = Path(job.run_dir) / "manifest.out"
+
+    if not log_path.exists():
+        raise HTTPException(status_code=404, detail="Manifest log not found")
+
+    if not _validate_log_path(job.run_dir, log_path):
+        raise HTTPException(status_code=403, detail="Invalid log path")
+
+    async def generate():
+        """Generate SSE events from log file."""
+        try:
+            async with aiofiles.open(log_path, mode="r") as f:
+                # Send existing content
+                content = await f.read()
+                if content:
+                    for line in content.split("\n"):
+                        yield f"data: {line}\n\n"
+
+                # Follow for new content (tail -f style)
+                while True:
+                    line = await f.readline()
+                    if line:
+                        yield f"data: {line.rstrip()}\n\n"
+                    else:
+                        # Send heartbeat to keep connection alive
+                        yield ": heartbeat\n\n"
+                        await asyncio.sleep(2)
+        except asyncio.CancelledError:
+            pass
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@router.get("/{job_id}/manifest/content")
+async def get_manifest_log_content(
+    request: Request,
+    job_id: int,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get manifest log content as plain text.
+
+    Args:
+        job_id: Job ID.
+
+    Returns:
+        Log content.
+    """
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    job = await job_service.get_job(job_id)
+
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    log_path = Path(job.run_dir) / "manifest.out"
+
+    if not log_path.exists():
+        return {"content": "", "exists": False}
+
+    if not _validate_log_path(job.run_dir, log_path):
+        raise HTTPException(status_code=403, detail="Invalid log path")
+
+    try:
+        content = log_path.read_text()
+        return {"content": content, "exists": True}
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Error reading log: {e}")
+
+
+@router.get("/{job_id}/shard/{shard_id}")
+async def get_shard_log(
+    request: Request,
+    job_id: int,
+    shard_id: int,
+    attempt: int = 1,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Get shard log content.
+
+    Args:
+        job_id: Job ID.
+        shard_id: Shard ID.
+        attempt: Attempt number (default 1).
+
+    Returns:
+        Log content.
+    """
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    job = await job_service.get_job(job_id)
+
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    log_path = Path(job.run_dir) / "logs" / f"shard_{shard_id}_attempt_{attempt}.log"
+
+    if not _validate_log_path(job.run_dir, log_path):
+        raise HTTPException(status_code=403, detail="Invalid log path")
+
+    if not log_path.exists():
+        # Try to find any attempt
+        logs_dir = Path(job.run_dir) / "logs"
+        available = []
+        if logs_dir.exists():
+            for f in logs_dir.glob(f"shard_{shard_id}_attempt_*.log"):
+                try:
+                    att = int(f.stem.split("_")[-1])
+                    available.append(att)
+                except ValueError:
+                    pass
+
+        return {
+            "content": "",
+            "exists": False,
+            "shard_id": shard_id,
+            "attempt": attempt,
+            "available_attempts": sorted(available),
+        }
+
+    try:
+        content = log_path.read_text()
+        return {
+            "content": content,
+            "exists": True,
+            "shard_id": shard_id,
+            "attempt": attempt,
+        }
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Error reading log: {e}")
+
+
+@router.get("/{job_id}/shards")
+async def list_shard_logs(
+    request: Request,
+    job_id: int,
+    user: User = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """List available shard logs for a job.
+
+    Args:
+        job_id: Job ID.
+
+    Returns:
+        List of available shard logs.
+    """
+    config = request.app.state.config
+    job_service = JobService(config, db)
+    job = await job_service.get_job(job_id)
+
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    logs_dir = Path(job.run_dir) / "logs"
+
+    if not logs_dir.exists():
+        return {"shards": []}
+
+    # Parse log filenames to get shard info
+    shards = {}
+    for f in logs_dir.glob("shard_*_attempt_*.log"):
+        try:
+            parts = f.stem.split("_")
+            shard_id = int(parts[1])
+            attempt = int(parts[3])
+
+            if shard_id not in shards:
+                shards[shard_id] = {"shard_id": shard_id, "attempts": []}
+            shards[shard_id]["attempts"].append(attempt)
+        except (ValueError, IndexError):
+            continue
+
+    # Sort attempts
+    for shard in shards.values():
+        shard["attempts"].sort()
+
+    return {"shards": sorted(shards.values(), key=lambda x: x["shard_id"])}

--- a/src/xfer/dashboard/api/remotes.py
+++ b/src/xfer/dashboard/api/remotes.py
@@ -1,0 +1,88 @@
+"""API endpoints for rclone remote discovery."""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, Request
+
+from ..auth import User, require_auth
+from ..services.rclone_service import (
+    get_allowed_local_prefixes,
+    get_allowed_remotes,
+)
+
+router = APIRouter(prefix="/api", tags=["remotes"])
+
+
+@router.get("/remotes")
+async def list_remotes(
+    request: Request,
+    user: User = Depends(require_auth),
+) -> dict:
+    """List available rclone remotes and local path prefixes.
+
+    Returns remotes parsed from the admin-configured rclone.conf that
+    match the allowed_prefixes configuration.
+
+    Returns:
+        Dictionary with 'remotes' and 'local_prefixes' lists.
+    """
+    config = request.app.state.config
+
+    # Get allowed remotes from rclone.conf
+    remotes = get_allowed_remotes(
+        config.slurm.rclone_config,
+        config.paths.allowed_prefixes,
+    )
+
+    # Get allowed local prefixes
+    local_prefixes = get_allowed_local_prefixes(config.paths.allowed_prefixes)
+
+    return {
+        "remotes": [r.to_dict() for r in remotes],
+        "local_prefixes": local_prefixes,
+    }
+
+
+@router.get("/remotes/sources")
+async def list_source_options(
+    request: Request,
+    user: User = Depends(require_auth),
+) -> List[dict]:
+    """List all available source options for the job creation form.
+
+    Combines remotes and local prefixes into a unified list for UI dropdowns.
+
+    Returns:
+        List of source options with 'value', 'label', and 'type' fields.
+    """
+    config = request.app.state.config
+
+    options = []
+
+    # Add remotes
+    remotes = get_allowed_remotes(
+        config.slurm.rclone_config,
+        config.paths.allowed_prefixes,
+    )
+    for remote in remotes:
+        options.append(
+            {
+                "value": remote.prefix,
+                "label": remote.display_name,
+                "type": "remote",
+                "remote_type": remote.type,
+            }
+        )
+
+    # Add local prefixes
+    local_prefixes = get_allowed_local_prefixes(config.paths.allowed_prefixes)
+    for prefix in local_prefixes:
+        options.append(
+            {
+                "value": prefix,
+                "label": f"Local: {prefix}",
+                "type": "local",
+            }
+        )
+
+    return options

--- a/src/xfer/dashboard/api/routes.py
+++ b/src/xfer/dashboard/api/routes.py
@@ -1,0 +1,13 @@
+"""API router aggregation."""
+
+from fastapi import APIRouter
+
+from . import jobs, logs, remotes
+
+# Create main API router
+api_router = APIRouter()
+
+# Include sub-routers
+api_router.include_router(jobs.router)
+api_router.include_router(logs.router)
+api_router.include_router(remotes.router)

--- a/src/xfer/dashboard/auth.py
+++ b/src/xfer/dashboard/auth.py
@@ -1,0 +1,166 @@
+"""Google SSO authentication and session handling."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from fastapi_sso.sso.google import GoogleSSO
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .config import DashboardConfig
+from .db.models import User
+from .db.session import get_db
+
+
+def create_google_sso(config: DashboardConfig) -> GoogleSSO:
+    """Create Google SSO instance from config.
+
+    Args:
+        config: Dashboard configuration.
+
+    Returns:
+        Configured GoogleSSO instance.
+    """
+    return GoogleSSO(
+        client_id=config.auth.google.client_id,
+        client_secret=config.auth.google.client_secret,
+        redirect_uri=f"{config.server.base_url}/auth/callback",
+        allow_insecure_http=config.server.debug,
+    )
+
+
+async def get_current_user(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Optional[User]:
+    """Get current user from session.
+
+    Args:
+        request: FastAPI request.
+        db: Database session.
+
+    Returns:
+        User instance if authenticated, None otherwise.
+    """
+    user_id = request.session.get("user_id")
+    if not user_id:
+        return None
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def require_auth(
+    request: Request,
+    user: Optional[User] = Depends(get_current_user),
+) -> User:
+    """Require authenticated user, raise 401 if not.
+
+    Args:
+        request: FastAPI request.
+        user: Current user (from dependency).
+
+    Returns:
+        Authenticated user.
+
+    Raises:
+        HTTPException: If user is not authenticated.
+    """
+    if not user:
+        # For API requests, return 401
+        accept = request.headers.get("accept", "")
+        if "application/json" in accept:
+            raise HTTPException(status_code=401, detail="Not authenticated")
+        # For browser requests, redirect to login
+        raise HTTPException(
+            status_code=302,
+            headers={"Location": "/login"},
+        )
+    return user
+
+
+async def login_redirect(request: Request) -> RedirectResponse:
+    """Initiate Google OAuth login flow.
+
+    Args:
+        request: FastAPI request.
+
+    Returns:
+        Redirect to Google OAuth consent page.
+    """
+    config: DashboardConfig = request.app.state.config
+    google_sso = create_google_sso(config)
+
+    with google_sso:
+        return await google_sso.get_login_redirect()
+
+
+async def auth_callback(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """Handle Google OAuth callback.
+
+    Args:
+        request: FastAPI request.
+        db: Database session.
+
+    Returns:
+        Redirect to dashboard on success.
+
+    Raises:
+        HTTPException: If domain is not allowed or auth fails.
+    """
+    config: DashboardConfig = request.app.state.config
+    google_sso = create_google_sso(config)
+
+    with google_sso:
+        user_info = await google_sso.verify_and_process(request)
+
+    if not user_info or not user_info.email:
+        raise HTTPException(status_code=400, detail="Failed to get user info from Google")
+
+    # Check domain restriction
+    email_domain = user_info.email.split("@")[1]
+    if email_domain not in config.auth.google.allowed_domains:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Domain '{email_domain}' is not allowed. "
+            f"Allowed domains: {', '.join(config.auth.google.allowed_domains)}",
+        )
+
+    # Get or create user
+    result = await db.execute(select(User).where(User.email == user_info.email))
+    user = result.scalar_one_or_none()
+
+    if not user:
+        user = User(
+            email=user_info.email,
+            name=user_info.display_name,
+            picture_url=user_info.picture,
+        )
+        db.add(user)
+        await db.flush()
+
+    user.last_login_at = datetime.utcnow()
+    await db.commit()
+
+    # Set session
+    request.session["user_id"] = user.id
+
+    return RedirectResponse(url="/", status_code=302)
+
+
+async def logout(request: Request) -> RedirectResponse:
+    """Log out user by clearing session.
+
+    Args:
+        request: FastAPI request.
+
+    Returns:
+        Redirect to login page.
+    """
+    request.session.clear()
+    return RedirectResponse(url="/login", status_code=302)

--- a/src/xfer/dashboard/config.py
+++ b/src/xfer/dashboard/config.py
@@ -1,0 +1,153 @@
+"""Admin configuration loading and validation."""
+
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class GoogleAuthConfig(BaseModel):
+    """Google OAuth2 configuration."""
+
+    client_id: str
+    client_secret: str
+    allowed_domains: List[str]
+
+
+class SessionConfig(BaseModel):
+    """Session configuration."""
+
+    secret_key: str
+    cookie_name: str = "xfer_session"
+    max_age_seconds: int = 86400
+
+
+class AuthConfig(BaseModel):
+    """Authentication configuration."""
+
+    google: GoogleAuthConfig
+    session: SessionConfig
+
+
+class DatabaseConfig(BaseModel):
+    """Database configuration."""
+
+    url: str = "sqlite+aiosqlite:///./xfer_dashboard.db"
+
+
+class SlurmConfig(BaseModel):
+    """Slurm job configuration (admin-controlled)."""
+
+    rclone_image: str = "rclone/rclone:latest"
+    rclone_config: Path
+    num_shards: int = 256
+    array_concurrency: int = 64
+    partitions: List[str] = ["standard"]
+    cpus_per_task: int = 4
+    mem: str = "8G"
+    time_limit: str = "24:00:00"
+    max_attempts: int = 5
+    rclone_flags: str = "--transfers 32 --checkers 64 --fast-list --retries 10 --low-level-retries 20"
+    pyxis_extra: str = ""
+
+    @field_validator("rclone_config", mode="before")
+    @classmethod
+    def validate_rclone_config(cls, v):
+        return Path(v) if isinstance(v, str) else v
+
+
+class PathsConfig(BaseModel):
+    """Path restrictions configuration."""
+
+    run_base_dir: Path
+    allowed_prefixes: List[str]
+
+    @field_validator("run_base_dir", mode="before")
+    @classmethod
+    def validate_run_base_dir(cls, v):
+        return Path(v) if isinstance(v, str) else v
+
+
+class ServerConfig(BaseModel):
+    """Server configuration."""
+
+    host: str = "0.0.0.0"
+    port: int = 8000
+    base_url: str
+    debug: bool = False
+
+
+class DashboardConfig(BaseModel):
+    """Root dashboard configuration."""
+
+    schema_version: str = Field(default="xfer.dashboard.config.v1", alias="schema")
+    auth: AuthConfig
+    database: DatabaseConfig
+    slurm: SlurmConfig
+    paths: PathsConfig
+    server: ServerConfig
+
+    class Config:
+        populate_by_name = True
+
+
+def find_config_file() -> Optional[Path]:
+    """Find the dashboard configuration file.
+
+    Searches in order:
+    1. XFER_DASHBOARD_CONFIG environment variable
+    2. /etc/xfer/dashboard.yaml
+    3. ~/.config/xfer/dashboard.yaml
+    4. ./dashboard.yaml (current directory)
+    """
+    import os
+
+    # Check environment variable
+    env_path = os.environ.get("XFER_DASHBOARD_CONFIG")
+    if env_path:
+        path = Path(env_path)
+        if path.exists():
+            return path
+
+    # Check standard locations
+    candidates = [
+        Path("/etc/xfer/dashboard.yaml"),
+        Path.home() / ".config" / "xfer" / "dashboard.yaml",
+        Path("dashboard.yaml"),
+    ]
+
+    for path in candidates:
+        if path.exists():
+            return path
+
+    return None
+
+
+def load_config(path: Optional[Path] = None) -> DashboardConfig:
+    """Load dashboard configuration from YAML file.
+
+    Args:
+        path: Path to config file. If None, searches standard locations.
+
+    Returns:
+        Validated DashboardConfig instance.
+
+    Raises:
+        FileNotFoundError: If no config file is found.
+        ValueError: If config validation fails.
+    """
+    if path is None:
+        path = find_config_file()
+
+    if path is None:
+        raise FileNotFoundError(
+            "No dashboard configuration file found. "
+            "Create one at /etc/xfer/dashboard.yaml, ~/.config/xfer/dashboard.yaml, "
+            "or set XFER_DASHBOARD_CONFIG environment variable."
+        )
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    return DashboardConfig.model_validate(data)

--- a/src/xfer/dashboard/db/__init__.py
+++ b/src/xfer/dashboard/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database models and session management."""

--- a/src/xfer/dashboard/db/models.py
+++ b/src/xfer/dashboard/db/models.py
@@ -1,0 +1,146 @@
+"""SQLAlchemy ORM models for the dashboard."""
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Base class for all models."""
+
+    pass
+
+
+class JobStatus(str, Enum):
+    """Job status enumeration."""
+
+    PENDING = "pending"
+    MANIFEST_QUEUED = "manifest_queued"
+    MANIFEST_RUNNING = "manifest_running"
+    MANIFEST_FAILED = "manifest_failed"
+    MANIFEST_DONE = "manifest_done"
+    TRANSFER_QUEUED = "transfer_queued"
+    TRANSFER_RUNNING = "transfer_running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class User(Base):
+    """User model for Google SSO authenticated users."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    picture_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    last_login_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    # Relationships
+    jobs: Mapped[List["Job"]] = relationship("Job", back_populates="created_by")
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, email={self.email!r})>"
+
+
+class Job(Base):
+    """Transfer job model."""
+
+    __tablename__ = "jobs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # User-provided fields
+    tag: Mapped[str] = mapped_column(String(100), nullable=False)
+    source_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+    dest_path: Mapped[str] = mapped_column(String(1024), nullable=False)
+
+    # System-generated fields
+    run_id: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    run_dir: Mapped[str] = mapped_column(String(1024), nullable=False)
+
+    # Admin config snapshot (frozen at job creation)
+    config_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+    # Status tracking
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default=JobStatus.PENDING.value
+    )
+
+    # Slurm job IDs
+    manifest_slurm_job_id: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    transfer_slurm_job_id: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+
+    # User relationship
+    created_by_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=True
+    )
+    created_by: Mapped[Optional["User"]] = relationship("User", back_populates="jobs")
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    # Cached progress (updated by background task)
+    num_shards: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    shards_done: Mapped[int] = mapped_column(Integer, default=0)
+    shards_failed: Mapped[int] = mapped_column(Integer, default=0)
+    shards_running: Mapped[int] = mapped_column(Integer, default=0)
+    total_bytes: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    manifest_object_count: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    # Error info
+    error_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # Relationships
+    status_history: Mapped[List["JobStatusHistory"]] = relationship(
+        "JobStatusHistory", back_populates="job", cascade="all, delete-orphan"
+    )
+
+    @property
+    def job_name(self) -> str:
+        """Get the Slurm job name."""
+        return f"xfer_{self.tag}"
+
+    @property
+    def manifest_job_name(self) -> str:
+        """Get the manifest Slurm job name."""
+        return f"xfer_{self.tag}_manifest"
+
+    @property
+    def progress_percent(self) -> float:
+        """Get completion percentage."""
+        if not self.num_shards or self.num_shards == 0:
+            return 0.0
+        return (self.shards_done / self.num_shards) * 100
+
+    def __repr__(self) -> str:
+        return f"<Job(id={self.id}, tag={self.tag!r}, status={self.status!r})>"
+
+
+class JobStatusHistory(Base):
+    """Audit log for job status changes."""
+
+    __tablename__ = "job_status_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False
+    )
+    old_status: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    new_status: Mapped[str] = mapped_column(String(32), nullable=False)
+    message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    # Relationships
+    job: Mapped["Job"] = relationship("Job", back_populates="status_history")
+
+    def __repr__(self) -> str:
+        return f"<JobStatusHistory(job_id={self.job_id}, {self.old_status} -> {self.new_status})>"

--- a/src/xfer/dashboard/db/session.py
+++ b/src/xfer/dashboard/db/session.py
@@ -1,0 +1,95 @@
+"""Database session management."""
+
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from .models import Base
+
+# Global engine and session factory (initialized by init_db)
+_engine = None
+_async_session_factory = None
+
+
+async def init_db(database_url: str) -> None:
+    """Initialize the database engine and create tables.
+
+    Args:
+        database_url: SQLAlchemy async database URL.
+    """
+    global _engine, _async_session_factory
+
+    _engine = create_async_engine(
+        database_url,
+        echo=False,
+        future=True,
+    )
+
+    _async_session_factory = async_sessionmaker(
+        _engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    # Create tables
+    async with _engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def close_db() -> None:
+    """Close the database engine."""
+    global _engine, _async_session_factory
+
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+        _async_session_factory = None
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """FastAPI dependency for database sessions.
+
+    Yields:
+        AsyncSession instance.
+
+    Example:
+        @app.get("/items")
+        async def list_items(db: AsyncSession = Depends(get_db)):
+            result = await db.execute(select(Item))
+            return result.scalars().all()
+    """
+    if _async_session_factory is None:
+        raise RuntimeError("Database not initialized. Call init_db() first.")
+
+    async with _async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@asynccontextmanager
+async def get_db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Context manager for database sessions (for use outside FastAPI).
+
+    Yields:
+        AsyncSession instance.
+
+    Example:
+        async with get_db_session() as db:
+            result = await db.execute(select(Item))
+            items = result.scalars().all()
+    """
+    if _async_session_factory is None:
+        raise RuntimeError("Database not initialized. Call init_db() first.")
+
+    async with _async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise

--- a/src/xfer/dashboard/main.py
+++ b/src/xfer/dashboard/main.py
@@ -1,0 +1,192 @@
+"""FastAPI application factory and entry point."""
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
+
+from . import auth
+from .config import DashboardConfig, load_config
+from .db.models import User
+from .db.session import close_db, init_db
+
+# Template directory
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+STATIC_DIR = Path(__file__).parent / "static"
+
+
+def create_app(config: Optional[DashboardConfig] = None) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Args:
+        config: Dashboard configuration. If None, loads from file.
+
+    Returns:
+        Configured FastAPI application.
+    """
+    if config is None:
+        config = load_config()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        """Application lifespan handler."""
+        # Startup
+        await init_db(config.database.url)
+
+        # Start background tasks
+        poll_task = asyncio.create_task(progress_polling_task(app))
+
+        yield
+
+        # Shutdown
+        poll_task.cancel()
+        try:
+            await poll_task
+        except asyncio.CancelledError:
+            pass
+        await close_db()
+
+    app = FastAPI(
+        title="xfer Dashboard",
+        description="Web interface for managing xfer data transfer jobs",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+
+    # Store config in app state
+    app.state.config = config
+
+    # Add session middleware
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=config.auth.session.secret_key,
+        session_cookie=config.auth.session.cookie_name,
+        max_age=config.auth.session.max_age_seconds,
+        same_site="lax",
+        https_only=not config.server.debug,
+    )
+
+    # Mount static files
+    if STATIC_DIR.exists():
+        app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+    # Set up templates
+    templates = Jinja2Templates(directory=TEMPLATE_DIR)
+    app.state.templates = templates
+
+    # Register routes
+    register_routes(app, templates)
+
+    # Include API routers
+    from .api.routes import api_router
+    app.include_router(api_router)
+
+    return app
+
+
+def register_routes(app: FastAPI, templates: Jinja2Templates) -> None:
+    """Register all routes on the application.
+
+    Args:
+        app: FastAPI application.
+        templates: Jinja2 templates instance.
+    """
+    # Auth routes
+    @app.get("/login", response_class=HTMLResponse)
+    async def login_page(request: Request):
+        """Show login page."""
+        return templates.TemplateResponse(
+            "login.html",
+            {"request": request},
+        )
+
+    @app.get("/auth/login")
+    async def login_redirect_route(request: Request):
+        """Redirect to Google OAuth."""
+        return await auth.login_redirect(request)
+
+    @app.get("/auth/callback")
+    async def auth_callback_route(
+        request: Request,
+        db=Depends(auth.get_db),
+    ):
+        """Handle Google OAuth callback."""
+        return await auth.auth_callback(request, db)
+
+    @app.get("/auth/logout")
+    async def logout_route(request: Request):
+        """Log out user."""
+        return await auth.logout(request)
+
+    # Dashboard routes
+    @app.get("/", response_class=HTMLResponse)
+    async def dashboard(
+        request: Request,
+        user: User = Depends(auth.require_auth),
+    ):
+        """Show main dashboard."""
+        return templates.TemplateResponse(
+            "dashboard.html",
+            {"request": request, "user": user},
+        )
+
+    # Health check
+    @app.get("/health")
+    async def health_check():
+        """Health check endpoint."""
+        return {"status": "ok"}
+
+    # API info
+    @app.get("/api")
+    async def api_info():
+        """API information endpoint."""
+        return {
+            "name": "xfer Dashboard API",
+            "version": "0.1.0",
+            "docs": "/docs",
+        }
+
+
+async def progress_polling_task(app: FastAPI) -> None:
+    """Background task to poll job progress from state directories.
+
+    Args:
+        app: FastAPI application.
+    """
+    from .db.session import get_db_session
+    from .services.state_service import update_all_active_jobs
+
+    while True:
+        try:
+            async with get_db_session() as db:
+                await update_all_active_jobs(db)
+        except Exception as e:
+            # Log error but keep polling
+            print(f"Error in progress polling: {e}")
+
+        await asyncio.sleep(30)
+
+
+def run() -> None:
+    """Entry point for running the dashboard server."""
+    import uvicorn
+
+    config = load_config()
+    app = create_app(config)
+
+    uvicorn.run(
+        app,
+        host=config.server.host,
+        port=config.server.port,
+        log_level="info" if not config.server.debug else "debug",
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/src/xfer/dashboard/services/__init__.py
+++ b/src/xfer/dashboard/services/__init__.py
@@ -1,0 +1,1 @@
+"""Business logic services."""

--- a/src/xfer/dashboard/services/job_service.py
+++ b/src/xfer/dashboard/services/job_service.py
@@ -1,0 +1,381 @@
+"""Job orchestration service."""
+
+import os
+import re
+import shlex
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..config import DashboardConfig
+from ..db.models import Job, JobStatus, JobStatusHistory
+from .rclone_service import validate_path
+from .slurm_service import cancel_jobs, get_job_state, submit_job
+
+
+def generate_run_id() -> str:
+    """Generate a unique run ID.
+
+    Returns:
+        Run ID in format "YYYY-MM-DDTHH:MM:SSZ_hexrandom".
+    """
+    ts = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    rnd = os.urandom(3).hex()
+    return f"{ts}_{rnd}"
+
+
+def validate_tag(tag: str) -> bool:
+    """Validate job tag format.
+
+    Args:
+        tag: Tag to validate.
+
+    Returns:
+        True if tag is valid.
+    """
+    # Allow alphanumeric, hyphens, and underscores
+    # 1-50 characters
+    pattern = r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,49}$"
+    return bool(re.match(pattern, tag))
+
+
+# Manifest job script template
+MANIFEST_JOB_SCRIPT = r"""#!/usr/bin/env bash
+#SBATCH --job-name={manifest_job_name}
+#SBATCH --output={run_dir}/manifest.out
+#SBATCH --error={run_dir}/manifest.err
+#SBATCH --partition={partition}
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=16G
+#SBATCH --time=4:00:00
+
+set -euo pipefail
+
+cd "{run_dir}"
+
+echo "== $(date -Is) Starting manifest build =="
+
+# Build manifest
+xfer manifest build \
+    --source {source_path} \
+    --dest {dest_path} \
+    --out manifest.jsonl \
+    --rclone-image {rclone_image} \
+    --rclone-config {rclone_config} \
+    --recursive --fast-list
+
+echo "== $(date -Is) Manifest build complete =="
+
+# Count objects in manifest
+OBJECT_COUNT=$(wc -l < manifest.jsonl)
+echo "Objects in manifest: ${{OBJECT_COUNT}}"
+
+# Shard manifest
+xfer manifest shard \
+    --in manifest.jsonl \
+    --outdir shards \
+    --num-shards {num_shards}
+
+echo "== $(date -Is) Sharding complete =="
+
+# Render Slurm scripts
+xfer slurm render \
+    --run-dir . \
+    --num-shards {num_shards} \
+    --array-concurrency {array_concurrency} \
+    --job-name {transfer_job_name} \
+    --partition {partition} \
+    --cpus-per-task {cpus_per_task} \
+    --mem {mem} \
+    --time-limit {time_limit} \
+    --rclone-image {rclone_image} \
+    --rclone-config {rclone_config} \
+    --rclone-flags {rclone_flags} \
+    --max-attempts {max_attempts}
+
+echo "== $(date -Is) Render complete =="
+
+# Submit transfer array job and capture job ID
+TRANSFER_JOB_ID=$(sbatch --parsable sbatch_array.sh)
+echo "TRANSFER_JOB_ID=${{TRANSFER_JOB_ID}}" > transfer_job_id.txt
+echo "Submitted transfer array job: ${{TRANSFER_JOB_ID}}"
+
+echo "== $(date -Is) Complete =="
+"""
+
+
+class JobService:
+    """Service for managing transfer jobs."""
+
+    def __init__(self, config: DashboardConfig, db: AsyncSession):
+        """Initialize job service.
+
+        Args:
+            config: Dashboard configuration.
+            db: Database session.
+        """
+        self.config = config
+        self.db = db
+
+    async def create_job(
+        self,
+        tag: str,
+        source_path: str,
+        dest_path: str,
+        user_id: Optional[int] = None,
+    ) -> Job:
+        """Create a new transfer job and submit manifest job to Slurm.
+
+        Args:
+            tag: User-provided job tag.
+            source_path: Source rclone path.
+            dest_path: Destination rclone path.
+            user_id: ID of user creating the job.
+
+        Returns:
+            Created Job instance.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+        # Validate tag
+        if not validate_tag(tag):
+            raise ValueError(
+                "Invalid tag. Must be 1-50 characters, alphanumeric with hyphens/underscores, "
+                "starting with alphanumeric."
+            )
+
+        # Validate paths
+        if not validate_path(source_path, self.config.paths.allowed_prefixes):
+            raise ValueError(f"Source path '{source_path}' is not in allowed prefixes.")
+
+        if not validate_path(dest_path, self.config.paths.allowed_prefixes):
+            raise ValueError(f"Destination path '{dest_path}' is not in allowed prefixes.")
+
+        # Generate run ID and directory
+        run_id = generate_run_id()
+        run_dir = self.config.paths.run_base_dir / f"xfer_{tag}_{run_id.replace(':', '-')}"
+
+        # Create job record
+        job = Job(
+            tag=tag,
+            source_path=source_path,
+            dest_path=dest_path,
+            run_id=run_id,
+            run_dir=str(run_dir),
+            config_snapshot=self.config.slurm.model_dump(mode="json"),
+            status=JobStatus.PENDING.value,
+            created_by_id=user_id,
+            num_shards=self.config.slurm.num_shards,
+        )
+
+        self.db.add(job)
+        await self.db.flush()
+
+        # Create run directory
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate manifest job script
+        script_content = self._generate_manifest_script(job)
+        script_path = run_dir / "manifest_job.sh"
+        script_path.write_text(script_content)
+        script_path.chmod(0o755)
+
+        # Submit manifest job to Slurm
+        try:
+            manifest_job_id = await submit_job(str(script_path))
+            job.manifest_slurm_job_id = manifest_job_id
+            job.status = JobStatus.MANIFEST_QUEUED.value
+            job.started_at = datetime.utcnow()
+        except RuntimeError as e:
+            job.status = JobStatus.FAILED.value
+            job.error_message = str(e)
+
+        await self._log_status_change(job, JobStatus.PENDING.value, job.status)
+        await self.db.commit()
+
+        return job
+
+    def _generate_manifest_script(self, job: Job) -> str:
+        """Generate the manifest job sbatch script.
+
+        Args:
+            job: Job instance.
+
+        Returns:
+            Script content.
+        """
+        config = self.config.slurm
+
+        return MANIFEST_JOB_SCRIPT.format(
+            manifest_job_name=job.manifest_job_name,
+            run_dir=job.run_dir,
+            partition=config.partitions[0],
+            source_path=shlex.quote(job.source_path),
+            dest_path=shlex.quote(job.dest_path),
+            rclone_image=shlex.quote(config.rclone_image),
+            rclone_config=shlex.quote(str(config.rclone_config)),
+            num_shards=config.num_shards,
+            array_concurrency=config.array_concurrency,
+            transfer_job_name=shlex.quote(job.job_name),
+            cpus_per_task=config.cpus_per_task,
+            mem=shlex.quote(config.mem),
+            time_limit=shlex.quote(config.time_limit),
+            rclone_flags=shlex.quote(config.rclone_flags),
+            max_attempts=config.max_attempts,
+        )
+
+    async def cancel_job(self, job_id: int) -> Job:
+        """Cancel a running job.
+
+        Args:
+            job_id: Job ID to cancel.
+
+        Returns:
+            Updated Job instance.
+
+        Raises:
+            ValueError: If job not found or cannot be cancelled.
+        """
+        job = await self.get_job(job_id)
+        if job is None:
+            raise ValueError(f"Job {job_id} not found.")
+
+        # Collect Slurm job IDs to cancel
+        slurm_jobs = []
+        if job.manifest_slurm_job_id:
+            slurm_jobs.append(job.manifest_slurm_job_id)
+        if job.transfer_slurm_job_id:
+            slurm_jobs.append(job.transfer_slurm_job_id)
+
+        if slurm_jobs:
+            await cancel_jobs(slurm_jobs)
+
+        old_status = job.status
+        job.status = JobStatus.CANCELLED.value
+        job.completed_at = datetime.utcnow()
+
+        await self._log_status_change(job, old_status, job.status, "Cancelled by user")
+        await self.db.commit()
+
+        return job
+
+    async def get_job(self, job_id: int) -> Optional[Job]:
+        """Get a job by ID.
+
+        Args:
+            job_id: Job ID.
+
+        Returns:
+            Job instance or None.
+        """
+        result = await self.db.execute(select(Job).where(Job.id == job_id))
+        return result.scalar_one_or_none()
+
+    async def list_jobs(self, limit: int = 100) -> list[Job]:
+        """List recent jobs.
+
+        Args:
+            limit: Maximum number of jobs to return.
+
+        Returns:
+            List of Job instances.
+        """
+        result = await self.db.execute(
+            select(Job).order_by(Job.created_at.desc()).limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def update_job_status(self, job: Job) -> None:
+        """Update job status based on Slurm job states.
+
+        Args:
+            job: Job to update.
+        """
+        old_status = job.status
+
+        # Check manifest job status
+        if job.status in (JobStatus.MANIFEST_QUEUED.value, JobStatus.MANIFEST_RUNNING.value):
+            if job.manifest_slurm_job_id:
+                state = await get_job_state(job.manifest_slurm_job_id)
+                if state:
+                    if state.upper() == "RUNNING":
+                        job.status = JobStatus.MANIFEST_RUNNING.value
+                    elif state.upper() == "COMPLETED":
+                        # Manifest done, check for transfer job ID
+                        await self._check_transfer_job_submitted(job)
+                    elif state.upper() in ("FAILED", "CANCELLED", "TIMEOUT"):
+                        job.status = JobStatus.MANIFEST_FAILED.value
+                        job.completed_at = datetime.utcnow()
+
+        # Check transfer job status
+        elif job.status in (
+            JobStatus.MANIFEST_DONE.value,
+            JobStatus.TRANSFER_QUEUED.value,
+            JobStatus.TRANSFER_RUNNING.value,
+        ):
+            if job.transfer_slurm_job_id:
+                state = await get_job_state(job.transfer_slurm_job_id)
+                if state:
+                    if state.upper() in ("PENDING", "CONFIGURING"):
+                        job.status = JobStatus.TRANSFER_QUEUED.value
+                    elif state.upper() == "RUNNING":
+                        job.status = JobStatus.TRANSFER_RUNNING.value
+                    elif state.upper() == "COMPLETED":
+                        job.status = JobStatus.COMPLETED.value
+                        job.completed_at = datetime.utcnow()
+                    elif state.upper() in ("FAILED", "CANCELLED", "TIMEOUT"):
+                        job.status = JobStatus.FAILED.value
+                        job.completed_at = datetime.utcnow()
+
+        if job.status != old_status:
+            await self._log_status_change(job, old_status, job.status)
+
+    async def _check_transfer_job_submitted(self, job: Job) -> None:
+        """Check if transfer job was submitted and update job accordingly.
+
+        Args:
+            job: Job to check.
+        """
+        run_dir = Path(job.run_dir)
+        job_id_file = run_dir / "transfer_job_id.txt"
+
+        if job_id_file.exists():
+            content = job_id_file.read_text().strip()
+            # Parse "TRANSFER_JOB_ID=12345"
+            for line in content.split("\n"):
+                if line.startswith("TRANSFER_JOB_ID="):
+                    job.transfer_slurm_job_id = line.split("=", 1)[1].strip()
+                    job.status = JobStatus.TRANSFER_QUEUED.value
+                    break
+            else:
+                job.status = JobStatus.MANIFEST_DONE.value
+        else:
+            # File not yet written, manifest might have just finished
+            job.status = JobStatus.MANIFEST_DONE.value
+
+    async def _log_status_change(
+        self,
+        job: Job,
+        old_status: str,
+        new_status: str,
+        message: Optional[str] = None,
+    ) -> None:
+        """Log a job status change.
+
+        Args:
+            job: Job instance.
+            old_status: Previous status.
+            new_status: New status.
+            message: Optional message.
+        """
+        history = JobStatusHistory(
+            job_id=job.id,
+            old_status=old_status,
+            new_status=new_status,
+            message=message,
+        )
+        self.db.add(history)

--- a/src/xfer/dashboard/services/rclone_service.py
+++ b/src/xfer/dashboard/services/rclone_service.py
@@ -1,0 +1,178 @@
+"""rclone configuration parsing and remote discovery."""
+
+import configparser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass
+class RcloneRemote:
+    """Represents an rclone remote configuration."""
+
+    name: str
+    type: str
+    endpoint: Optional[str] = None
+    provider: Optional[str] = None
+    region: Optional[str] = None
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable name for UI display."""
+        if self.endpoint:
+            return f"{self.name} ({self.endpoint})"
+        if self.provider and self.provider != "Other":
+            return f"{self.name} ({self.provider})"
+        return self.name
+
+    @property
+    def prefix(self) -> str:
+        """Get the rclone prefix for this remote (e.g., 's3-src:')."""
+        return f"{self.name}:"
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "name": self.name,
+            "type": self.type,
+            "endpoint": self.endpoint,
+            "provider": self.provider,
+            "region": self.region,
+            "display_name": self.display_name,
+            "prefix": self.prefix,
+        }
+
+
+def parse_rclone_config(config_path: Path) -> List[RcloneRemote]:
+    """Parse rclone.conf INI file and extract remote configurations.
+
+    Args:
+        config_path: Path to rclone.conf file.
+
+    Returns:
+        List of RcloneRemote instances.
+
+    Example rclone.conf format:
+        [s3-src]
+        type = s3
+        provider = Other
+        endpoint = https://s3.example.com
+        access_key_id = ...
+        secret_access_key = ...
+    """
+    if not config_path.exists():
+        return []
+
+    config = configparser.ConfigParser()
+    config.read(config_path)
+
+    remotes = []
+    for section in config.sections():
+        remote_type = config.get(section, "type", fallback="")
+        remotes.append(
+            RcloneRemote(
+                name=section,
+                type=remote_type,
+                endpoint=config.get(section, "endpoint", fallback=None),
+                provider=config.get(section, "provider", fallback=None),
+                region=config.get(section, "region", fallback=None),
+            )
+        )
+
+    return remotes
+
+
+def get_allowed_remotes(
+    config_path: Path,
+    allowed_prefixes: List[str],
+) -> List[RcloneRemote]:
+    """Get remotes that match the admin-allowed prefixes.
+
+    Args:
+        config_path: Path to rclone.conf file.
+        allowed_prefixes: List of allowed path prefixes from admin config.
+
+    Returns:
+        List of allowed RcloneRemote instances.
+    """
+    all_remotes = parse_rclone_config(config_path)
+    allowed = []
+
+    for remote in all_remotes:
+        remote_prefix = remote.prefix
+        for prefix in allowed_prefixes:
+            # Match if the allowed prefix starts with the remote name
+            # e.g., "s3-src:" matches allowed prefix "s3-src:"
+            # e.g., "s3-src:" matches allowed prefix "s3-src:bucket/"
+            if prefix.startswith(remote_prefix) or remote_prefix == prefix:
+                allowed.append(remote)
+                break
+
+    return allowed
+
+
+def get_allowed_local_prefixes(allowed_prefixes: List[str]) -> List[str]:
+    """Extract local filesystem prefixes from allowed prefixes.
+
+    Args:
+        allowed_prefixes: List of allowed path prefixes from admin config.
+
+    Returns:
+        List of local filesystem path prefixes (those starting with '/').
+    """
+    return [p for p in allowed_prefixes if p.startswith("/")]
+
+
+def validate_path(path: str, allowed_prefixes: List[str]) -> bool:
+    """Validate that a path matches at least one allowed prefix.
+
+    Args:
+        path: Path to validate.
+        allowed_prefixes: List of allowed path prefixes.
+
+    Returns:
+        True if path is allowed, False otherwise.
+    """
+    for prefix in allowed_prefixes:
+        if path.startswith(prefix):
+            return True
+    return False
+
+
+def is_remote_path(path: str) -> bool:
+    """Check if a path is an rclone remote path (contains ':').
+
+    Args:
+        path: Path to check.
+
+    Returns:
+        True if path is a remote path, False otherwise.
+    """
+    # Remote paths have format "remote:path" but we need to exclude
+    # Windows absolute paths like "C:\path" (though unlikely on Linux)
+    if ":" not in path:
+        return False
+    # Check if it looks like a remote (letters/digits/hyphens before colon)
+    colon_idx = path.index(":")
+    if colon_idx == 0:
+        return False
+    remote_name = path[:colon_idx]
+    return all(c.isalnum() or c in "-_" for c in remote_name)
+
+
+def split_remote_path(path: str) -> tuple[Optional[str], str]:
+    """Split a path into remote name and path components.
+
+    Args:
+        path: Full path (e.g., "s3-src:bucket/prefix" or "/scratch/data").
+
+    Returns:
+        Tuple of (remote_name, path). remote_name is None for local paths.
+    """
+    if not is_remote_path(path):
+        return None, path
+
+    colon_idx = path.index(":")
+    remote_name = path[:colon_idx]
+    remaining_path = path[colon_idx + 1 :]
+    return remote_name, remaining_path

--- a/src/xfer/dashboard/services/slurm_service.py
+++ b/src/xfer/dashboard/services/slurm_service.py
@@ -1,0 +1,197 @@
+"""Slurm interaction service."""
+
+import asyncio
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+
+@dataclass
+class SlurmJobInfo:
+    """Information about a Slurm job."""
+
+    job_id: str
+    name: str
+    state: str
+    elapsed: Optional[str] = None
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
+    exit_code: Optional[int] = None
+
+
+async def submit_job(script_path: str) -> str:
+    """Submit a job to Slurm via sbatch.
+
+    Args:
+        script_path: Path to the sbatch script.
+
+    Returns:
+        Slurm job ID.
+
+    Raises:
+        RuntimeError: If sbatch fails.
+    """
+    result = await asyncio.to_thread(
+        subprocess.run,
+        ["sbatch", "--parsable", script_path],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"sbatch failed: {result.stderr}")
+
+    # sbatch --parsable returns job_id or job_id;cluster
+    job_id = result.stdout.strip().split(";")[0]
+    return job_id
+
+
+async def cancel_jobs(job_ids: List[str]) -> None:
+    """Cancel one or more Slurm jobs.
+
+    Args:
+        job_ids: List of Slurm job IDs to cancel.
+    """
+    if not job_ids:
+        return
+
+    await asyncio.to_thread(
+        subprocess.run,
+        ["scancel"] + job_ids,
+        capture_output=True,
+        check=False,
+    )
+
+
+async def get_job_info(job_id: str) -> Optional[SlurmJobInfo]:
+    """Get information about a Slurm job.
+
+    Args:
+        job_id: Slurm job ID.
+
+    Returns:
+        SlurmJobInfo if found, None otherwise.
+    """
+    result = await asyncio.to_thread(
+        subprocess.run,
+        [
+            "sacct",
+            "-j",
+            job_id,
+            "--format=JobID,JobName,State,Elapsed,Start,End,ExitCode",
+            "--noheader",
+            "--parsable2",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    # Parse first line (main job, not steps)
+    lines = result.stdout.strip().split("\n")
+    for line in lines:
+        parts = line.split("|")
+        if len(parts) >= 7:
+            # Skip job steps (contain '.')
+            if "." in parts[0]:
+                continue
+
+            exit_code = None
+            if parts[6] and ":" in parts[6]:
+                # Format is "exit_code:signal"
+                try:
+                    exit_code = int(parts[6].split(":")[0])
+                except ValueError:
+                    pass
+
+            return SlurmJobInfo(
+                job_id=parts[0],
+                name=parts[1],
+                state=parts[2],
+                elapsed=parts[3] if parts[3] else None,
+                start_time=_parse_slurm_time(parts[4]),
+                end_time=_parse_slurm_time(parts[5]),
+                exit_code=exit_code,
+            )
+
+    return None
+
+
+async def get_job_state(job_id: str) -> Optional[str]:
+    """Get the state of a Slurm job.
+
+    Args:
+        job_id: Slurm job ID.
+
+    Returns:
+        Job state string (e.g., "PENDING", "RUNNING", "COMPLETED"), or None.
+    """
+    info = await get_job_info(job_id)
+    return info.state if info else None
+
+
+async def is_job_running(job_id: str) -> bool:
+    """Check if a Slurm job is still running or pending.
+
+    Args:
+        job_id: Slurm job ID.
+
+    Returns:
+        True if job is running or pending.
+    """
+    state = await get_job_state(job_id)
+    if state is None:
+        return False
+    return state.upper() in ("PENDING", "RUNNING", "CONFIGURING", "COMPLETING")
+
+
+async def is_job_completed(job_id: str) -> bool:
+    """Check if a Slurm job has completed successfully.
+
+    Args:
+        job_id: Slurm job ID.
+
+    Returns:
+        True if job completed successfully.
+    """
+    state = await get_job_state(job_id)
+    if state is None:
+        return False
+    return state.upper() == "COMPLETED"
+
+
+async def is_job_failed(job_id: str) -> bool:
+    """Check if a Slurm job has failed.
+
+    Args:
+        job_id: Slurm job ID.
+
+    Returns:
+        True if job failed.
+    """
+    state = await get_job_state(job_id)
+    if state is None:
+        return False
+    return state.upper() in ("FAILED", "CANCELLED", "TIMEOUT", "NODE_FAIL", "PREEMPTED")
+
+
+def _parse_slurm_time(time_str: str) -> Optional[datetime]:
+    """Parse Slurm timestamp format.
+
+    Args:
+        time_str: Slurm timestamp (e.g., "2024-01-15T10:30:00").
+
+    Returns:
+        datetime object or None if parsing fails.
+    """
+    if not time_str or time_str == "Unknown":
+        return None
+
+    try:
+        return datetime.fromisoformat(time_str)
+    except ValueError:
+        return None

--- a/src/xfer/dashboard/services/state_service.py
+++ b/src/xfer/dashboard/services/state_service.py
@@ -1,0 +1,249 @@
+"""State directory monitoring service."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db.models import Job, JobStatus
+
+
+@dataclass
+class ShardState:
+    """State of a single shard."""
+
+    shard_id: int
+    is_done: bool = False
+    is_failed: bool = False
+    attempt_count: int = 0
+    exit_code: Optional[int] = None
+
+
+@dataclass
+class JobProgress:
+    """Progress information for a job."""
+
+    total_shards: int
+    done: int
+    failed: int
+    running: int
+    pending: int
+
+    done_ids: List[int]
+    failed_ids: List[int]
+    running_ids: List[int]
+
+    @property
+    def percent_complete(self) -> float:
+        """Get completion percentage."""
+        if self.total_shards == 0:
+            return 0.0
+        return (self.done / self.total_shards) * 100
+
+    @property
+    def percent_failed(self) -> float:
+        """Get failure percentage."""
+        if self.total_shards == 0:
+            return 0.0
+        return (self.failed / self.total_shards) * 100
+
+
+class StateService:
+    """Service for monitoring job state directories."""
+
+    def get_shard_state(self, run_dir: Path, shard_id: int) -> ShardState:
+        """Get state of a specific shard.
+
+        Args:
+            run_dir: Path to run directory.
+            shard_id: Shard ID.
+
+        Returns:
+            ShardState instance.
+        """
+        state_dir = run_dir / "state"
+        state = ShardState(shard_id=shard_id)
+
+        # Check done file
+        done_file = state_dir / f"shard_{shard_id}.done"
+        state.is_done = done_file.exists()
+
+        # Check fail file
+        fail_file = state_dir / f"shard_{shard_id}.fail"
+        if fail_file.exists():
+            state.is_failed = True
+            try:
+                content = fail_file.read_text().strip()
+                state.exit_code = int(content)
+            except (ValueError, OSError):
+                pass
+
+        # Check attempt file
+        attempt_file = state_dir / f"shard_{shard_id}.attempt"
+        if attempt_file.exists():
+            try:
+                content = attempt_file.read_text().strip()
+                state.attempt_count = int(content)
+            except (ValueError, OSError):
+                pass
+
+        return state
+
+    def get_job_progress(self, run_dir: Path, num_shards: int) -> JobProgress:
+        """Get progress for a job from its state directory.
+
+        Args:
+            run_dir: Path to run directory.
+            num_shards: Total number of shards.
+
+        Returns:
+            JobProgress instance.
+
+        State directory structure:
+        - state/shard_{id}.done  - empty file, indicates completion
+        - state/shard_{id}.fail  - contains exit code
+        - state/shard_{id}.attempt - contains attempt count
+        """
+        state_dir = Path(run_dir) / "state"
+
+        if not state_dir.exists():
+            return JobProgress(
+                total_shards=num_shards,
+                done=0,
+                failed=0,
+                running=0,
+                pending=num_shards,
+                done_ids=[],
+                failed_ids=[],
+                running_ids=[],
+            )
+
+        # Collect state file information
+        done_ids: Set[int] = set()
+        fail_ids: Set[int] = set()
+        attempt_ids: Set[int] = set()
+
+        for f in state_dir.glob("shard_*.done"):
+            shard_id = self._extract_shard_id(f)
+            if shard_id is not None:
+                done_ids.add(shard_id)
+
+        for f in state_dir.glob("shard_*.fail"):
+            shard_id = self._extract_shard_id(f)
+            if shard_id is not None:
+                fail_ids.add(shard_id)
+
+        for f in state_dir.glob("shard_*.attempt"):
+            shard_id = self._extract_shard_id(f)
+            if shard_id is not None:
+                attempt_ids.add(shard_id)
+
+        # Calculate states
+        # Failed = has .fail but no .done (could have retried to success)
+        failed_ids = fail_ids - done_ids
+
+        # Running = has .attempt but no .done or .fail
+        running_ids = attempt_ids - done_ids - fail_ids
+
+        # Pending = total - done - failed - running
+        done_count = len(done_ids)
+        failed_count = len(failed_ids)
+        running_count = len(running_ids)
+        pending_count = max(0, num_shards - done_count - failed_count - running_count)
+
+        return JobProgress(
+            total_shards=num_shards,
+            done=done_count,
+            failed=failed_count,
+            running=running_count,
+            pending=pending_count,
+            done_ids=sorted(done_ids),
+            failed_ids=sorted(failed_ids),
+            running_ids=sorted(running_ids),
+        )
+
+    def _extract_shard_id(self, path: Path) -> Optional[int]:
+        """Extract shard ID from state file path.
+
+        Args:
+            path: Path like "shard_123.done".
+
+        Returns:
+            Shard ID or None if parsing fails.
+        """
+        try:
+            # shard_123.done -> shard_123 -> 123
+            name = path.stem  # shard_123
+            parts = name.split("_")
+            if len(parts) >= 2:
+                return int(parts[1])
+        except (ValueError, IndexError):
+            pass
+        return None
+
+    def get_manifest_stats(self, run_dir: Path) -> Optional[Dict]:
+        """Get manifest statistics from shards.meta.json.
+
+        Args:
+            run_dir: Path to run directory.
+
+        Returns:
+            Dictionary with manifest stats or None.
+        """
+        meta_file = Path(run_dir) / "shards" / "shards.meta.json"
+        if not meta_file.exists():
+            return None
+
+        try:
+            with open(meta_file) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+
+async def update_all_active_jobs(db: AsyncSession) -> None:
+    """Update progress for all active jobs.
+
+    Args:
+        db: Database session.
+    """
+    from .job_service import JobService
+
+    # Get all active jobs
+    active_statuses = [
+        JobStatus.MANIFEST_QUEUED.value,
+        JobStatus.MANIFEST_RUNNING.value,
+        JobStatus.MANIFEST_DONE.value,
+        JobStatus.TRANSFER_QUEUED.value,
+        JobStatus.TRANSFER_RUNNING.value,
+    ]
+
+    result = await db.execute(select(Job).where(Job.status.in_(active_statuses)))
+    jobs = result.scalars().all()
+
+    state_service = StateService()
+
+    for job in jobs:
+        run_dir = Path(job.run_dir)
+
+        # Update shard progress from state directory
+        if job.num_shards and run_dir.exists():
+            progress = state_service.get_job_progress(run_dir, job.num_shards)
+            job.shards_done = progress.done
+            job.shards_failed = progress.failed
+            job.shards_running = progress.running
+
+            # Get manifest stats if available
+            stats = state_service.get_manifest_stats(run_dir)
+            if stats:
+                job.manifest_object_count = stats.get("num_records")
+                job.total_bytes = stats.get("bytes_total")
+
+        # Update job status from Slurm (this is imported here to avoid circular imports)
+        # Note: We need the config to create JobService, which we don't have here
+        # So we'll just update the progress and let the status update happen elsewhere
+
+    await db.commit()

--- a/src/xfer/dashboard/templates/base.html
+++ b/src/xfer/dashboard/templates/base.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}xfer Dashboard{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <style>
+        [x-cloak] { display: none !important; }
+    </style>
+    {% block head %}{% endblock %}
+</head>
+<body class="bg-gray-100 min-h-screen">
+    <nav class="bg-indigo-600 text-white shadow-lg">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16 items-center">
+                <div class="flex items-center">
+                    <a href="/" class="text-xl font-bold">xfer Dashboard</a>
+                </div>
+                {% if user %}
+                <div class="flex items-center gap-4">
+                    {% if user.picture_url %}
+                    <img src="{{ user.picture_url }}" alt="" class="w-8 h-8 rounded-full">
+                    {% endif %}
+                    <span class="text-sm">{{ user.email }}</span>
+                    <a href="/auth/logout" class="text-sm hover:underline">Logout</a>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
+
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="bg-white border-t mt-auto">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 text-center text-gray-500 text-sm">
+            xfer Dashboard &copy; {{ now().year if now else "2025" }}
+        </div>
+    </footer>
+
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/src/xfer/dashboard/templates/dashboard.html
+++ b/src/xfer/dashboard/templates/dashboard.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard - xfer{% endblock %}
+
+{% block content %}
+<div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold text-gray-900">Transfer Jobs</h1>
+    <a href="/jobs/new"
+       class="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors">
+        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        New Transfer
+    </a>
+</div>
+
+<!-- Jobs table with htmx polling -->
+<div id="jobs-container"
+     hx-get="/htmx/jobs/table"
+     hx-trigger="load, every 30s"
+     hx-swap="innerHTML">
+    <div class="bg-white rounded-lg shadow p-8 text-center text-gray-500">
+        Loading jobs...
+    </div>
+</div>
+{% endblock %}

--- a/src/xfer/dashboard/templates/jobs/create.html
+++ b/src/xfer/dashboard/templates/jobs/create.html
@@ -1,0 +1,129 @@
+{% extends "base.html" %}
+
+{% block title %}New Transfer - xfer Dashboard{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+    <h1 class="text-2xl font-bold text-gray-900 mb-6">Create New Transfer</h1>
+
+    {% if error %}
+    <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+        <div class="flex">
+            <svg class="w-5 h-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+            </svg>
+            <p class="ml-3 text-red-700">{{ error }}</p>
+        </div>
+    </div>
+    {% endif %}
+
+    <form method="POST" action="/jobs" class="bg-white rounded-lg shadow-md p-6">
+        <!-- Job Tag -->
+        <div class="mb-6">
+            <label for="tag" class="block text-sm font-medium text-gray-700 mb-2">
+                Job Tag
+            </label>
+            <input type="text"
+                   id="tag"
+                   name="tag"
+                   required
+                   pattern="[a-zA-Z0-9][a-zA-Z0-9_-]*"
+                   maxlength="50"
+                   placeholder="my-dataset-backup"
+                   value="{{ form_data.tag if form_data else '' }}"
+                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+            <p class="mt-1 text-sm text-gray-500">
+                Used for job naming: <code class="bg-gray-100 px-1 rounded">xfer_{tag}</code>
+            </p>
+        </div>
+
+        <!-- Source Path -->
+        <div class="mb-6" x-data="{
+            remote: '{{ form_data.source_path.split(':')[0] + ':' if form_data and ':' in form_data.source_path else (remotes[0].prefix if remotes else '') }}',
+            path: '{{ form_data.source_path.split(':')[1] if form_data and ':' in form_data.source_path else '' }}'
+        }">
+            <label class="block text-sm font-medium text-gray-700 mb-2">
+                Source Path
+            </label>
+            <div class="flex gap-2">
+                <select x-model="remote"
+                        class="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                    {% for r in remotes %}
+                    <option value="{{ r.prefix }}">{{ r.display_name }}</option>
+                    {% endfor %}
+                    {% for prefix in local_prefixes %}
+                    <option value="{{ prefix }}">Local: {{ prefix }}</option>
+                    {% endfor %}
+                </select>
+                <input type="text"
+                       x-model="path"
+                       placeholder="bucket/prefix/path"
+                       class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+            </div>
+            <input type="hidden" name="source_path" :value="remote + path">
+        </div>
+
+        <!-- Destination Path -->
+        <div class="mb-6" x-data="{
+            remote: '{{ form_data.dest_path.split(':')[0] + ':' if form_data and ':' in form_data.dest_path else (remotes[1].prefix if remotes|length > 1 else (remotes[0].prefix if remotes else '')) }}',
+            path: '{{ form_data.dest_path.split(':')[1] if form_data and ':' in form_data.dest_path else '' }}'
+        }">
+            <label class="block text-sm font-medium text-gray-700 mb-2">
+                Destination Path
+            </label>
+            <div class="flex gap-2">
+                <select x-model="remote"
+                        class="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                    {% for r in remotes %}
+                    <option value="{{ r.prefix }}">{{ r.display_name }}</option>
+                    {% endfor %}
+                    {% for prefix in local_prefixes %}
+                    <option value="{{ prefix }}">Local: {{ prefix }}</option>
+                    {% endfor %}
+                </select>
+                <input type="text"
+                       x-model="path"
+                       placeholder="bucket/prefix/path"
+                       class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+            </div>
+            <input type="hidden" name="dest_path" :value="remote + path">
+        </div>
+
+        <!-- Admin Settings (read-only) -->
+        <div class="bg-gray-50 rounded-lg p-4 mb-6">
+            <h3 class="text-sm font-medium text-gray-700 mb-3">Admin Settings (pre-configured)</h3>
+            <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                <dt class="text-gray-500">Shards:</dt>
+                <dd class="text-gray-900">{{ config.slurm.num_shards }}</dd>
+
+                <dt class="text-gray-500">Concurrency:</dt>
+                <dd class="text-gray-900">{{ config.slurm.array_concurrency }}</dd>
+
+                <dt class="text-gray-500">Partition:</dt>
+                <dd class="text-gray-900">{{ config.slurm.partitions[0] }}</dd>
+
+                <dt class="text-gray-500">CPUs/Task:</dt>
+                <dd class="text-gray-900">{{ config.slurm.cpus_per_task }}</dd>
+
+                <dt class="text-gray-500">Memory:</dt>
+                <dd class="text-gray-900">{{ config.slurm.mem }}</dd>
+
+                <dt class="text-gray-500">Time Limit:</dt>
+                <dd class="text-gray-900">{{ config.slurm.time_limit }}</dd>
+            </dl>
+        </div>
+
+        <!-- Submit -->
+        <div class="flex justify-end gap-3">
+            <a href="/"
+               class="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">
+                Cancel
+            </a>
+            <button type="submit"
+                    class="px-6 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors">
+                Submit Transfer Job
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/src/xfer/dashboard/templates/jobs/detail.html
+++ b/src/xfer/dashboard/templates/jobs/detail.html
@@ -1,0 +1,176 @@
+{% extends "base.html" %}
+
+{% block title %}Job: {{ job.tag }} - xfer Dashboard{% endblock %}
+
+{% block content %}
+<div class="mb-6">
+    <a href="/" class="text-indigo-600 hover:text-indigo-800">&larr; Back to Jobs</a>
+</div>
+
+<div class="bg-white rounded-lg shadow-md overflow-hidden">
+    <!-- Header -->
+    <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+        <div>
+            <h1 class="text-xl font-bold text-gray-900">{{ job.job_name }}</h1>
+            <p class="text-sm text-gray-500">Created {{ job.created_at.strftime('%Y-%m-%d %H:%M:%S UTC') if job.created_at else 'Unknown' }}</p>
+        </div>
+        <div class="flex items-center gap-3">
+            {% set status_colors = {
+                'pending': 'bg-gray-100 text-gray-800',
+                'manifest_queued': 'bg-yellow-100 text-yellow-800',
+                'manifest_running': 'bg-blue-100 text-blue-800',
+                'manifest_failed': 'bg-red-100 text-red-800',
+                'manifest_done': 'bg-green-100 text-green-800',
+                'transfer_queued': 'bg-yellow-100 text-yellow-800',
+                'transfer_running': 'bg-blue-100 text-blue-800',
+                'completed': 'bg-green-100 text-green-800',
+                'failed': 'bg-red-100 text-red-800',
+                'cancelled': 'bg-gray-100 text-gray-800'
+            } %}
+            <span class="px-3 py-1 rounded-full text-sm font-medium {{ status_colors.get(job.status, 'bg-gray-100 text-gray-800') }}">
+                {{ job.status.replace('_', ' ').title() }}
+            </span>
+            {% if job.status not in ['completed', 'failed', 'cancelled'] %}
+            <form method="POST" action="/jobs/{{ job.id }}/cancel" class="inline">
+                <button type="submit"
+                        onclick="return confirm('Are you sure you want to cancel this job?')"
+                        class="px-3 py-1 text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors text-sm">
+                    Cancel Job
+                </button>
+            </form>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Progress -->
+    <div id="progress-section"
+         hx-get="/htmx/jobs/{{ job.id }}/progress"
+         hx-trigger="every 10s"
+         hx-swap="innerHTML"
+         class="px-6 py-4 border-b border-gray-200">
+        {% include "partials/progress_bar.html" %}
+    </div>
+
+    <!-- Details -->
+    <div class="px-6 py-4">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">Job Details</h2>
+
+        <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Source</dt>
+                <dd class="mt-1 text-sm text-gray-900 font-mono bg-gray-50 px-2 py-1 rounded">{{ job.source_path }}</dd>
+            </div>
+
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Destination</dt>
+                <dd class="mt-1 text-sm text-gray-900 font-mono bg-gray-50 px-2 py-1 rounded">{{ job.dest_path }}</dd>
+            </div>
+
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Run ID</dt>
+                <dd class="mt-1 text-sm text-gray-900 font-mono">{{ job.run_id }}</dd>
+            </div>
+
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Run Directory</dt>
+                <dd class="mt-1 text-sm text-gray-900 font-mono text-xs break-all">{{ job.run_dir }}</dd>
+            </div>
+
+            {% if job.manifest_slurm_job_id %}
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Manifest Job ID</dt>
+                <dd class="mt-1 text-sm text-gray-900 font-mono">{{ job.manifest_slurm_job_id }}</dd>
+            </div>
+            {% endif %}
+
+            {% if job.transfer_slurm_job_id %}
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Transfer Job ID</dt>
+                <dd class="mt-1 text-sm text-gray-900 font-mono">{{ job.transfer_slurm_job_id }}</dd>
+            </div>
+            {% endif %}
+
+            {% if job.manifest_object_count %}
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Total Objects</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ "{:,}".format(job.manifest_object_count) }}</dd>
+            </div>
+            {% endif %}
+
+            {% if job.total_bytes %}
+            <div>
+                <dt class="text-sm font-medium text-gray-500">Total Size</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ "%.2f"|format(job.total_bytes / (1024**3)) }} GiB</dd>
+            </div>
+            {% endif %}
+        </dl>
+
+        {% if job.error_message %}
+        <div class="mt-6 bg-red-50 border border-red-200 rounded-lg p-4">
+            <h3 class="text-sm font-medium text-red-800 mb-2">Error</h3>
+            <pre class="text-sm text-red-700 whitespace-pre-wrap">{{ job.error_message }}</pre>
+        </div>
+        {% endif %}
+    </div>
+
+    <!-- Logs -->
+    <div class="px-6 py-4 border-t border-gray-200">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">Logs</h2>
+
+        <div x-data="{ activeTab: 'manifest' }">
+            <div class="border-b border-gray-200 mb-4">
+                <nav class="-mb-px flex gap-4">
+                    <button @click="activeTab = 'manifest'"
+                            :class="activeTab === 'manifest' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
+                            class="py-2 px-1 border-b-2 font-medium text-sm">
+                        Manifest Log
+                    </button>
+                    <button @click="activeTab = 'shards'"
+                            :class="activeTab === 'shards' ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700'"
+                            class="py-2 px-1 border-b-2 font-medium text-sm">
+                        Shard Logs
+                    </button>
+                </nav>
+            </div>
+
+            <!-- Manifest Log -->
+            <div x-show="activeTab === 'manifest'" x-cloak>
+                <div id="manifest-log"
+                     class="bg-gray-900 text-gray-100 rounded-lg p-4 font-mono text-sm h-64 overflow-auto">
+                    <div hx-get="/api/logs/{{ job.id }}/manifest/content"
+                         hx-trigger="load"
+                         hx-swap="innerHTML">
+                        Loading manifest log...
+                    </div>
+                </div>
+            </div>
+
+            <!-- Shard Logs -->
+            <div x-show="activeTab === 'shards'" x-cloak>
+                {% if progress and progress.failed_ids %}
+                <div class="mb-4">
+                    <h3 class="text-sm font-medium text-red-600 mb-2">Failed Shards</h3>
+                    <div class="flex flex-wrap gap-2">
+                        {% for shard_id in progress.failed_ids[:20] %}
+                        <a href="/api/logs/{{ job.id }}/shard/{{ shard_id }}"
+                           target="_blank"
+                           class="px-2 py-1 bg-red-100 text-red-700 rounded text-sm hover:bg-red-200">
+                            Shard {{ shard_id }}
+                        </a>
+                        {% endfor %}
+                        {% if progress.failed_ids|length > 20 %}
+                        <span class="text-gray-500 text-sm">...and {{ progress.failed_ids|length - 20 }} more</span>
+                        {% endif %}
+                    </div>
+                </div>
+                {% endif %}
+
+                <p class="text-sm text-gray-500">
+                    View individual shard logs via the API:
+                    <code class="bg-gray-100 px-1 rounded">/api/logs/{{ job.id }}/shard/{shard_id}</code>
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/xfer/dashboard/templates/jobs/list.html
+++ b/src/xfer/dashboard/templates/jobs/list.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Jobs - xfer Dashboard{% endblock %}
+
+{% block content %}
+<div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold text-gray-900">Transfer Jobs</h1>
+    <a href="/jobs/new"
+       class="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors">
+        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        New Transfer
+    </a>
+</div>
+
+<div id="jobs-container"
+     hx-get="/htmx/jobs/table"
+     hx-trigger="every 30s"
+     hx-swap="innerHTML">
+    {% include "partials/job_table.html" %}
+</div>
+{% endblock %}

--- a/src/xfer/dashboard/templates/login.html
+++ b/src/xfer/dashboard/templates/login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - xfer Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center">
+    <div class="bg-white p-8 rounded-lg shadow-md w-full max-w-md">
+        <div class="text-center mb-8">
+            <h1 class="text-3xl font-bold text-gray-900">xfer Dashboard</h1>
+            <p class="text-gray-600 mt-2">Manage your data transfer jobs</p>
+        </div>
+
+        <a href="/auth/login"
+           class="flex items-center justify-center gap-3 w-full bg-white border border-gray-300 rounded-lg px-4 py-3 text-gray-700 hover:bg-gray-50 transition-colors">
+            <svg class="w-5 h-5" viewBox="0 0 24 24">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            <span class="font-medium">Sign in with Google</span>
+        </a>
+
+        <p class="text-center text-gray-500 text-sm mt-6">
+            Only authorized domains are allowed to sign in.
+        </p>
+    </div>
+</body>
+</html>

--- a/src/xfer/dashboard/templates/partials/job_table.html
+++ b/src/xfer/dashboard/templates/partials/job_table.html
@@ -1,0 +1,90 @@
+{% if jobs %}
+<div class="bg-white rounded-lg shadow overflow-hidden">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Job</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Progress</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Source</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Destination</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+            {% for job in jobs %}
+            <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='/jobs/{{ job.id }}'">
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <div class="text-sm font-medium text-indigo-600">{{ job.job_name }}</div>
+                    <div class="text-xs text-gray-500">ID: {{ job.id }}</div>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    {% set status_colors = {
+                        'pending': 'bg-gray-100 text-gray-800',
+                        'manifest_queued': 'bg-yellow-100 text-yellow-800',
+                        'manifest_running': 'bg-blue-100 text-blue-800',
+                        'manifest_failed': 'bg-red-100 text-red-800',
+                        'manifest_done': 'bg-green-100 text-green-800',
+                        'transfer_queued': 'bg-yellow-100 text-yellow-800',
+                        'transfer_running': 'bg-blue-100 text-blue-800',
+                        'completed': 'bg-green-100 text-green-800',
+                        'failed': 'bg-red-100 text-red-800',
+                        'cancelled': 'bg-gray-100 text-gray-800'
+                    } %}
+                    <span class="px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full {{ status_colors.get(job.status, 'bg-gray-100 text-gray-800') }}">
+                        {{ job.status.replace('_', ' ').title() }}
+                    </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    {% if job.num_shards %}
+                    <div class="flex items-center">
+                        <div class="w-24 bg-gray-200 rounded-full h-2 mr-2">
+                            {% set pct = (job.shards_done / job.num_shards * 100) if job.num_shards else 0 %}
+                            {% set fail_pct = (job.shards_failed / job.num_shards * 100) if job.num_shards else 0 %}
+                            <div class="flex h-2 rounded-full overflow-hidden">
+                                <div class="bg-green-500" style="width: {{ pct }}%"></div>
+                                <div class="bg-red-500" style="width: {{ fail_pct }}%"></div>
+                            </div>
+                        </div>
+                        <span class="text-xs text-gray-500">{{ job.shards_done }}/{{ job.num_shards }}</span>
+                    </div>
+                    {% else %}
+                    <span class="text-xs text-gray-400">-</span>
+                    {% endif %}
+                </td>
+                <td class="px-6 py-4">
+                    <div class="text-sm text-gray-900 truncate max-w-xs" title="{{ job.source_path }}">
+                        {{ job.source_path }}
+                    </div>
+                </td>
+                <td class="px-6 py-4">
+                    <div class="text-sm text-gray-900 truncate max-w-xs" title="{{ job.dest_path }}">
+                        {{ job.dest_path }}
+                    </div>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {{ job.created_at.strftime('%Y-%m-%d %H:%M') if job.created_at else '-' }}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<div class="bg-white rounded-lg shadow p-8 text-center">
+    <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+    </svg>
+    <h3 class="mt-2 text-sm font-medium text-gray-900">No transfer jobs</h3>
+    <p class="mt-1 text-sm text-gray-500">Get started by creating a new transfer job.</p>
+    <div class="mt-6">
+        <a href="/jobs/new"
+           class="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+            New Transfer
+        </a>
+    </div>
+</div>
+{% endif %}

--- a/src/xfer/dashboard/templates/partials/progress_bar.html
+++ b/src/xfer/dashboard/templates/partials/progress_bar.html
@@ -1,0 +1,51 @@
+{% if job.num_shards %}
+<div>
+    <div class="flex justify-between items-center mb-2">
+        <span class="text-sm font-medium text-gray-700">Progress</span>
+        <span class="text-sm text-gray-500">{{ job.shards_done }} / {{ job.num_shards }} shards</span>
+    </div>
+
+    {% set pct_done = (job.shards_done / job.num_shards * 100) if job.num_shards else 0 %}
+    {% set pct_failed = (job.shards_failed / job.num_shards * 100) if job.num_shards else 0 %}
+    {% set pct_running = (job.shards_running / job.num_shards * 100) if job.num_shards else 0 %}
+
+    <div class="w-full bg-gray-200 rounded-full h-4 overflow-hidden">
+        <div class="h-full flex">
+            <div class="bg-green-500 transition-all duration-500" style="width: {{ pct_done }}%"></div>
+            <div class="bg-blue-500 transition-all duration-500" style="width: {{ pct_running }}%"></div>
+            <div class="bg-red-500 transition-all duration-500" style="width: {{ pct_failed }}%"></div>
+        </div>
+    </div>
+
+    <div class="flex gap-6 mt-2 text-sm">
+        <span class="flex items-center">
+            <span class="w-3 h-3 bg-green-500 rounded-full mr-1"></span>
+            <span class="text-gray-600">Done: {{ job.shards_done }}</span>
+        </span>
+        <span class="flex items-center">
+            <span class="w-3 h-3 bg-blue-500 rounded-full mr-1"></span>
+            <span class="text-gray-600">Running: {{ job.shards_running }}</span>
+        </span>
+        <span class="flex items-center">
+            <span class="w-3 h-3 bg-red-500 rounded-full mr-1"></span>
+            <span class="text-gray-600">Failed: {{ job.shards_failed }}</span>
+        </span>
+        {% if progress %}
+        <span class="flex items-center">
+            <span class="w-3 h-3 bg-gray-300 rounded-full mr-1"></span>
+            <span class="text-gray-600">Pending: {{ progress.pending }}</span>
+        </span>
+        {% endif %}
+    </div>
+
+    {% if pct_done >= 100 %}
+    <div class="mt-2 text-sm text-green-600 font-medium">
+        Transfer complete!
+    </div>
+    {% endif %}
+</div>
+{% else %}
+<div class="text-sm text-gray-500">
+    Progress information not yet available. Manifest building in progress...
+</div>
+{% endif %}


### PR DESCRIPTION
## Summary

- Adds a FastAPI-based web dashboard for creating and monitoring xfer data transfer jobs
- Implements Google Workspace SSO authentication with configurable domain restrictions
- Admin-controlled settings (shards, concurrency, partitions, resources) separate from user inputs
- Two-stage job submission keeps manifest creation off the login node (runs as Slurm batch job)
- Real-time progress monitoring via state directory polling
- Log streaming via Server-Sent Events
- Job cancellation support

## New Files

- `src/xfer/dashboard/` - Dashboard package (FastAPI app, services, templates)
- `docs/dashboard.md` - Comprehensive documentation
- `dashboard.yaml.example` - Example configuration file

## Installation

```bash
pip install -e ".[dashboard]"
```

## Test plan

- [ ] Install with dashboard extras and verify dependencies resolve
- [ ] Create `dashboard.yaml` from example and configure Google OAuth
- [ ] Run `xfer-dashboard` and verify server starts
- [ ] Test Google SSO login flow with allowed domain
- [ ] Test domain restriction (user from non-allowed domain should be rejected)
- [ ] Create a test transfer job and verify manifest Slurm job is submitted
- [ ] Monitor job progress and verify shard completion updates
- [ ] Test log streaming for manifest and shard logs
- [ ] Test job cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)